### PR TITLE
Add missing newline chars in printf(1)-ed strings

### DIFF
--- a/functions/__z.fish
+++ b/functions/__z.fish
@@ -12,7 +12,7 @@ function __z -d "Jump to a recent directory."
         printf "         -h --help     Print this help\n\n"
 
         if type -q fisher
-            printf "Run `fisher help z` for more information."
+            printf "Run `fisher help z` for more information.\n"
         end
     end
 
@@ -25,11 +25,11 @@ function __z -d "Jump to a recent directory."
         return 0
     else if set -q _flag_clean
         __z_clean
-        printf "%s cleaned!" $Z_DATA
+        printf "%s cleaned!\n" $Z_DATA
         return 0
     else if set -q _flag_purge
         echo > $Z_DATA
-        printf "%s purged!" $Z_DATA
+        printf "%s purged!\n" $Z_DATA
         return 0
     else if set -q _flag_delete
         sed -i -e "\:^$PWD|.*:d" $Z_DATA
@@ -129,7 +129,7 @@ function __z -d "Jump to a recent directory."
         end
 
         if test -z "$target"
-            printf "'%s' did not match any results" "$argv"
+            printf "'%s' did not match any results\n" "$argv"
             return 1
         end
 

--- a/test/z.fish
+++ b/test/z.fish
@@ -50,7 +50,7 @@ test "z -e foo"
 end
 
 test "! z -e kid"
-  "'kid' did not match any results1" = (z -e kid; echo $status)
+  (printf "'kid' did not match any results\n1") = (z -e kid; echo $status)
 end
 
 test "z -h"
@@ -66,7 +66,7 @@ test "z bar"
 end
 
 test "z kid"
-  "'kid' did not match any results1" = (z kid; and echo $PWD $status; or echo $status)
+  (printf "'kid' did not match any results\n1") = (z kid; and echo $PWD $status; or echo $status)
 end
 
 test "z --list foo"
@@ -78,5 +78,5 @@ test "list common path on stderr"
 end
 
 test "z -x works"
-  "'foo' did not match any results1" = (z foo; and z -x; and cd ..; and z foo; and echo $PWD $status; or echo $status;)
+  (printf "'foo' did not match any results\n1") = (z foo; and z -x; and cd ..; and z foo; and echo $PWD $status; or echo $status;)
 end


### PR DESCRIPTION
As `printf(1)` does not add a newline character after printing a string, as `echo(1)` does, this character must be explicitly added.  I don't know if the author was using `echo(1)` before and decided to use `printf(1)` for portability purposes but forgot to add the newlines, so I'm adding them.

And my conscience was dictating me to do it, as I was enraged by the amount of return chars it was generating while I was learning the tool :joy: 