### PR TITLE
Use a function for generating directory completions

### DIFF
--- a/functions/__z_add.fish
+++ b/functions/__z_add.fish
@@ -44,6 +44,4 @@ function __z_add -d "Add PATH to .z file"
     command mv $tmpfile $Z_DATA
     or command rm $tmpfile
   end
-
-  __z_complete
 end

--- a/functions/__z_clean.fish
+++ b/functions/__z_clean.fish
@@ -8,6 +8,4 @@ function __z_clean -d "Clean up .z file to remove paths no longer valid"
     end < $Z_DATA > $tmpfile
     command mv -f $tmpfile $Z_DATA
   end
-
-  __z_complete
 end

--- a/functions/__z_complete.fish
+++ b/functions/__z_complete.fish
@@ -1,8 +1,10 @@
 function __z_complete -d "add completions"
-  set -l __z_marks (string replace -r '\|.*' '' < $Z_DATA | string escape)
+  function __z_marks
+      printf "%s\n" (string replace -r '\|.*' '' < $Z_DATA)
+  end
 
-  complete -c $Z_CMD -a "$__z_marks" -f
-  complete -c $ZO_CMD -a "$__z_marks" -f
+  complete -c $Z_CMD -a "(__z_marks)" -f
+  complete -c $ZO_CMD -a "(__z_marks)" -f
 
   complete -c $Z_CMD -s c -l clean  -d "Cleans out $Z_DATA"
   complete -c $Z_CMD -s e -l echo   -d "Prints best match, no cd"


### PR DESCRIPTION
The old implementation used a variable to store generated
directory completions. Using a function to generate
completions has many benefits:

1. `__z_complete` doesn't have to be called every time
   an entry is added or removed to the data file.

2. When using a variable, on each subsequesnt call to `__z_complete`,
   the completions are added to _existing_ ones. So calling
   `__z_complete` on `--clean` is reduntant.

3. Completions weren't updated on --delete; handled automatically
   now.
