### PR TITLE
Remove unreachable --list logic

### DIFF
--- a/functions/__z.fish
+++ b/functions/__z.fish
@@ -144,6 +144,7 @@ function __z -d "Jump to a recent directory."
         # Handle list separately as it can print common path information to stderr
         # which cannot be captured from a subcommand.
         command awk -v t=(date +%s) -v list="list" -v typ="$typ" -v q="$q" -F "|" $z_script "$Z_DATA"
+        return
     else
         set target (command awk -v t=(date +%s) -v typ="$typ" -v q="$q" -F "|" $z_script "$Z_DATA")
 
@@ -154,11 +155,6 @@ function __z -d "Jump to a recent directory."
         if test -z "$target"
             printf "'%s' did not match any results\n" "$argv"
             return 1
-        end
-
-        if set -q _flag_list
-            echo "$target" | tr ";" "\n" | sort -nr
-            return 0
         end
 
         if set -q _flag_echo

--- a/functions/__z.fish
+++ b/functions/__z.fish
@@ -145,32 +145,32 @@ function __z -d "Jump to a recent directory."
         # which cannot be captured from a subcommand.
         command awk -v t=(date +%s) -v list="list" -v typ="$typ" -v q="$q" -F "|" $z_script "$Z_DATA"
         return
-    else
-        set target (command awk -v t=(date +%s) -v typ="$typ" -v q="$q" -F "|" $z_script "$Z_DATA")
+    end
 
-        if test "$status" -gt 0
-            return
-        end
+    set target (command awk -v t=(date +%s) -v typ="$typ" -v q="$q" -F "|" $z_script "$Z_DATA")
 
-        if test -z "$target"
-            printf "'%s' did not match any results\n" "$argv"
-            return 1
-        end
+    if test "$status" -gt 0
+        return
+    end
 
-        if set -q _flag_echo
-            printf "%s\n" "$target"
-        else if set -q _flag_directory
-            # Be careful, in msys2, explorer always return 1
-            if test "$OS" = Windows_NT
-                type -q explorer;and explorer "$target"; return 0;
-                echo "Cannot open file explorer"; return 1;
-            else
-                type -q xdg-open;and xdg-open "$target"; and return $status;
-                type -q open;and open "$target"; and return $status;
-                echo "Not sure how to open file manager"; and return 1;
-            end
+    if test -z "$target"
+        printf "'%s' did not match any results\n" "$argv"
+        return 1
+    end
+
+    if set -q _flag_echo
+        printf "%s\n" "$target"
+    else if set -q _flag_directory
+        # Be careful, in msys2, explorer always return 1
+        if test "$OS" = Windows_NT
+            type -q explorer;and explorer "$target"; return 0;
+            echo "Cannot open file explorer"; return 1;
         else
-            pushd "$target"
+            type -q xdg-open;and xdg-open "$target"; and return $status;
+            type -q open;and open "$target"; and return $status;
+            echo "Not sure how to open file manager"; and return 1;
         end
+    else
+        pushd "$target"
     end
 end


### PR DESCRIPTION
The `--list` option is processed here first with an `if` construct:
https://github.com/jethrokuan/z/blob/34d35b587012e9319dcc25cc73b02adeb11a8ce7/functions/__z.fish#L143-L147

It is checked for and acted upon again here, inside the *else* part of the aforementioned `if ` conditional:
https://github.com/jethrokuan/z/blob/34d35b587012e9319dcc25cc73b02adeb11a8ce7/functions/__z.fish#L159-L162

The second check will never run:
1. If `_flag_list` is set, the `awk` part is executed and the function returns (the if conditional is the last block in the function).
2. If `_flag_list` is not set, neither the `awk` part or the `tr` part is executed.