### PR TITLE
Add support for private mode of fish and add missing argument completetion

### DIFF
--- a/functions/__z_add.fish
+++ b/functions/__z_add.fish
@@ -1,4 +1,6 @@
 function __z_add -d "Add PATH to .z file"
+  set -q fish_private_mode; and return 0
+
   for i in $Z_EXCLUDE
     if string match -r $i $PWD > /dev/null
       return 0 #Path excluded

--- a/functions/__z_complete.fish
+++ b/functions/__z_complete.fish
@@ -13,4 +13,5 @@ function __z_complete -d "add completions"
   complete -c $Z_CMD -s r -l rank   -d "Searches by rank, cd"
   complete -c $Z_CMD -s t -l recent -d "Searches by recency, cd"
   complete -c $Z_CMD -s h -l help   -d "Print help"
+  complete -c $Z_CMD -s x -l delete -d "Removes the current directory from $Z_DATA"
 end


### PR DESCRIPTION
1. Stop tracking visited directories in [private mode](https://fishshell.com/docs/current/index.html#private-mode) of fish
2. Add argument completion for `-x` / `--delete`