### PR TITLE
More compliant to Fish private mode

### DIFF
--- a/functions/__z_add.fish
+++ b/functions/__z_add.fish
@@ -1,5 +1,5 @@
 function __z_add -d "Add PATH to .z file"
-    set -q fish_private_mode; and return 0
+    test -n "$fish_private_mode"; and return 0
 
     for i in $Z_EXCLUDE
         if string match -r $i $PWD >/dev/null


### PR DESCRIPTION
A little nitpicking, but this is more compliant to [Fish 's docs](https://fishshell.com/docs/current/#private-mode):

> If $fish_private_mode is **set to a non-empty value**, commands will not be written to the history file on disk.