### PR TITLE
Remove obsolete `__z_marks` function in `__z_complete`

### DIFF
--- a/functions/__z_complete.fish
+++ b/functions/__z_complete.fish
@@ -1,8 +1,4 @@
 function __z_complete -d "add completions"
-    function __z_marks
-        printf "%s\n" (string replace -r '\|.*' '' < $Z_DATA)
-    end
-
     complete -c $Z_CMD -a "(__z -l | string replace -r '^\\S*\\s*' '')" -f -k
     complete -c $ZO_CMD -a "(__z -l | string replace -r '^\\S*\\s*' '')" -f -k
 


### PR DESCRIPTION
It seems this function is no longer used after 97ca1fd1b281f5f240e7adb90d0a28f9eb4567db.