### PR TITLE
Stop logging common path to stderr

### DIFF
--- a/functions/__z.fish
+++ b/functions/__z.fish
@@ -68,9 +68,6 @@ function __z -d "Jump to a recent directory."
                         printf "%-10s %s\n", matches[x], x | cmd
                     }
                 }
-                if( common ) {
-                    printf "%-10s %s\n", "common:", common > "/dev/stderr"
-                }
             } else {
                 if( common ) best_match = common
                 print best_match

--- a/test/z.fish
+++ b/test/z.fish
@@ -60,8 +60,6 @@ cd_some
 
 @test "z --list foo" $pth/foo = (z --list foo 2>/dev/null | awk '{ print $2} ')
 
-@test "list common path on stderr" "common:    $pth/foo" = (z --list foo 2>&1 >/dev/null | grep common:)
-
 @test "z -x works" 1 = (begin; z foo; and z -x; and cd ..; and z foo; end >/dev/null; echo $status)
 
 rm -rf $pth


### PR DESCRIPTION
So I've taken a closer look at https://github.com/jethrokuan/z/issues/107. The cause of the issue is actually that if there's a common path it's logged to stderr (see the block I've removed). This seems like a bit of a mismatch for stderr, from the fish docs stderr is meant to be used for:

```
Standard error (stderr) for writing errors and warnings. Defaults to writing to the screen.
```

and I don't think the common path really counts as either. Removing it fixes the prompt messing up when completing.

Behaviour before this change:

![image](https://user-images.githubusercontent.com/7355199/162401791-8f8561a3-bc27-4199-9363-ddba17eb1552.png)

Behaviour after this change:

![image](https://user-images.githubusercontent.com/7355199/162401115-538f654f-f359-446d-986c-974631516a18.png)

As you can see the prompt is now no longer messed up when there's a common path prefix.

Now I'm not really that familiar with awk or this plugin, so I'm not sure if we need to do some further cleanup after this change. Or if this change would break anything (other than removing the common path logging via stderr from `z -l`). See these lines for something that I think we could clean up: https://github.com/jethrokuan/z/blob/master/functions/__z.fish#L140-L143. We could also do that after this PR.

Let me know what you think.